### PR TITLE
Make warnings strict and fatal; fix resulting fallout.

### DIFF
--- a/31_binary_search.cpp
+++ b/31_binary_search.cpp
@@ -1,6 +1,9 @@
 /* output
 */
 
+// suppress warning about iota using a half-open range
+#define RANGES_SUPPRESS_IOTA_WARNING
+
 #include <range/v3/algorithm/reverse.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/algorithm/binary_search.hpp>
@@ -9,8 +12,6 @@ namespace rng = ranges::v3;
 #include <vector>
 #include <iostream>
 using namespace std;
-
-auto print = [] (int i) { cout << i << " "; };
 
 int main() {
 

--- a/40_set_algos.cpp
+++ b/40_set_algos.cpp
@@ -36,14 +36,14 @@ int main() {
 
   {
     vector<int> u;
-    auto it = rng::set_union(s1, s2, rng::back_inserter(u));
+    rng::set_union(s1, s2, rng::back_inserter(u));
     cout << "union: ";
     output(u);
   }
 
   {
     vector<int> u;
-    auto it = rng::set_intersection(s1, s2, rng::back_inserter(u));
+    rng::set_intersection(s1, s2, rng::back_inserter(u));
     cout << "intersection: ";
     output(u);
   }
@@ -68,7 +68,7 @@ int main() {
 
   {
     vector<int> u;
-    auto it = rng::set_symmetric_difference(
+    rng::set_symmetric_difference(
         s2.cbegin(), s2.cend(), s1.cbegin(), s1.cend(), rng::back_inserter(u));
     cout << "symmetric_difference: ";
     output(u);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ include_directories(${RANGE_INCLUDE})
 
 #probably not required for most
 add_definitions( -std=c++17 )
+add_definitions( -Wall -Wextra -Werror )   # all on and fatal by default
+add_definitions( -Wno-missing-braces )     # exclude those we disagree with
 
 add_executable( 01_hello 01_hello.cpp )
 add_executable( 02_foreach_sequence 02_foreach_sequence.cpp )


### PR DESCRIPTION
While suppressing the rng::iota warning it occurred to me we should maybe crank up the strictness on general principles.  Tested on clang 4.0.0 and g++ 6.3.0 (except for 11 and 50, which use structured bindings).